### PR TITLE
Bring back alarm_arm_xxx service calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/custom_components/bwalarm/resources/doc/configuration.md
+++ b/custom_components/bwalarm/resources/doc/configuration.md
@@ -3,7 +3,7 @@
 **Alarm.yaml configuration settings:**
 
 - platform: bwalarm **#[REQUIRED, String] Name of the custom alarm component. Do not change**
-- name: House **#[REQUIRED, String]This can be changed to whatever suits your need, ensure this attribute matches the one in your panel_custom.yaml 'alarmid: alarm_control_panel.house'**
+- name: House **#[OPTIONAL, String]This can be changed to whatever suits your need, ensure this attribute matches the one in your panel_custom.yaml 'alarmid: alarm_control_panel.house'**
 
 - code: '9876' **#[REQUIRED, digits] should consist of one or more digits ie '6482' ensure your passcode is encapsulated by quotes**
 - panic_code: '1234' **#[OPTIONAL, digits] Panic Code should consist of one or more digits ie '1234' ensure your passcode is encapsulated by quotes, it needs to be different to your standard alarm code. This enables a special panic mode. This can be used under duress to deactivate the alarm which would appear to the unseeing eye as deactivated however a special attribute [panic_mode] listed under the alarm_control_panel.[identifier] will change to ACTIVE. This status could be used in your automations to send a notification to someone else police/spouse/sibling/neighbour that you are under duress. To deactive this mode arm then disarm your alarm in the usual manner.**

--- a/custom_components/bwalarm/resources/doc/notes.md
+++ b/custom_components/bwalarm/resources/doc/notes.md
@@ -1,13 +1,14 @@
-Users
+##Users
 
-The component supports multiple users. To avoid any collisions they should have different names and passcodes.
+The integration supports multiple users. To avoid any collisions they should have different names and passcodes.
 
-Options
+##Options
 
-The components can be configured to request a passcode to set the alarm to prevent unauthorized access (Disabled by default).
+The integration can be configured to request a passcode to set alarm to prevent unauthorized access (Disabled by default).
 The passcode can be either master passcode or user passcode.
-There is a special code 'override' that can be used to arm immediately, i.e without waiting for Pendind Time configured. It works even if Request passcode to set the alarm is Disabled.
-This HA automation arms the alarm immediately
+There is a special code 'override' that can be used to set alarm immediately, i.e without waiting for Pending Time configured. It works even if Request passcode to set alarm is Disabled.
+
+This HA automation sets the alarm immediately
 ```
 alarm_arm_instant:
   sequence:
@@ -17,25 +18,57 @@ alarm_arm_instant:
       code: 'override'
 ```
 
-Arm modes
+##Arm modes
 There are Night (perimeter), Home and Away arm modes. They can be used as follows:
 Night: only entry/exit doors would trigger an alarm + outbuilding motion
 Home: all DOWNSTAIRS sensors would trigger an alarm
 Away: any/all sensors would trigger an alarm, entry/exit doors would be a delayed alarm
-The corresponding service calls are alarm_arm_perimeter, alarm_arm_home and alarm_arm_night.
 
-MQTT
+Please note that you can only set alarm to Night mode if it is enabled in the configuration file (manually in bwalarm.yaml or via Settings -> Sensors).
 
-When MQTT enabled, the component publishes its status to the state topic and listens to commands on the command topic (configurable via GUI/bwalarm.yaml).
-It supports three variations of arm and disarm commands (actual command names configurable via GUI/bwalarm.yaml).
-There is an option to disarm the alarm via MQTT message without passcode (Disabled by default).
+##Service calls
+For compatibility reasons there are currently 2 groups of service calls to set alarm:
+1. bwalarm.alarm_safe_arm_home, bwalarm.alarm_safe_arm_away and bwalarm.alarm_safe_arm_night
+2. alarm_control_panel.alarm_arm_home, alarm_control_panel.alarm_arm_away and alarm_control_panel.alarm_arm_night
+The difference is the services from the first group don't set the alarm if there are active sensors detected whilst the services from the second group always set alarm.
+
+##MQTT
+
+When MQTT enabled, the component publishes its status to the state topic and listens to commands on the command topic (configurable via Settings -> MQTT or manually in bwalarm.yaml).
+It supports three arm commands and one disarm command (actual command names are configurable via Settings -> MQTT or manually in bwalarm.yaml).
+There is an option to disarm  alarm via MQTT message without passcode (Disabled by default).
+Please note that MQTT ARM_HOME, ARM_AWAY and ARM_NIGHT commands set alarm using corresponding service call from the 1st group of service calls described above, i.e it doesn't set alarm if there are active sensors detected.
+
+All MQTT commands get their parameters in JSON format.
+
+ARM_XXX commands support the following optional parameters:
+entity_id: <string> # Full name (domain.object_id) of the bwalarm entity to control
+code: <string*> | <int>  # A code to arm alarm control panel with
+ignore_open_sensors: True | False # Arm even if there are active sensors detected. Default: False
+
+* if 'override' used, it sets alarm immediately, otherwise the alarm changes its state to Pending for Pending Time and then to a corresponding Armed_XXX state.
+
+ARM_DISARM command is similar and supports the following optional parameters:
+entity_id: <string> # Full name (domain.object_id) of the bwalarm entity to control
+code: <string> | <int>  # A code to arm alarm control panel with
+
 
 For example,
-  home/alarm/set ARM_AWAY
-arms the Away mode after a configured Pending Time,
-  home/alarm/set ARM_HOME 1234
-arms the Home mode using code after a configured Pending Time,
-  home/alarm/set DISARM
-disarms the alarm if Disarm Without Code is Enabled or
-  home/alarm/set DISARM 1234
-if it is Disabled
+
+```home/alarm/set ARM_AWAY```
+  arms the Away mode after a configured Pending Time if there is no active sensors detected
+
+```home/alarm/set ARM_HOME {"code":"override"}'```
+  arms the Home mode immediately if there is no active sensors detected
+
+```home/alarm/set ARM_HOME {"code": 1234}```
+  arms the Home mode using user/master code after a configured Pending Time if there is no active sensors detected
+
+```home/alarm/set ARM_AWAY {"ignore_open_sensors":True}```
+  arms the Away mode using user/master code after a configured Pending Time even if there are active sensors detected
+
+```home/alarm/set DISARM```
+  disarms the alarm if Disarm Without Code is Enabled
+
+```home/alarm/set DISARM {"code": "shazam"}```
+  disarms the alarm if Disarm Without Code is Disabled

--- a/custom_components/bwalarm/resources/panel.html
+++ b/custom_components/bwalarm/resources/panel.html
@@ -9,7 +9,7 @@ v
     const _NAME = 'Alarm Panel';
     const _URL = 'https://github.com/akasma74/Hass-Custom-Alarm';
     // don't forget to change HaPanelAlarm.version below!
-    const _VERSION = 'v1.7.1b';
+    const _VERSION = 'v1.8.0b';
 
     if (!window.CUSTOM_UI_LIST) window.CUSTOM_UI_LIST = [];
     window.CUSTOM_UI_LIST.push({
@@ -460,7 +460,7 @@ v
 
                       <div>
                         <h1>Your Versions:</h1>
-		        <div>
+                        <div>
                           <p><span class='info-header'>This integration: </span><span class='info-detail'>[[version]]</span></p>
                           <p><span class='info-header'>Home Assistant: </span><span class='info-detail'>v[[hass.config.version]]</span></p>
                           <p><span class='info-header'>Python: </span><span class='info-detail'>v([[alarm.attributes.py_version]])</span></p>
@@ -1410,7 +1410,7 @@ v
             switches:             { type: Array, value: [] },
 
             errors:               { type: Array },
-            version:              { type: String, value: 'v1.7.1b'},
+            version:              { type: String, value: 'v1.8.0b'},
 
             camera_update_interval: { type: Number, value: 5000 }, // ms
 
@@ -2444,12 +2444,14 @@ v
         alarmService(call){
           var data = {"entity_id": this.alarm.entity_id, "code": this.code}
 
+          // COMENTED OUT AS CURRENTLY alarm_control_panel SERVICE CALLS DO EXACTLY WHAT WE NEED
           // add extra parameters only to service calls that support them: arm_xxx_ext
           // and only if allowed (to avoid erors from Lovelace alarm card etc)
-          if (call == 'alarm_arm_home' || call == 'alarm_arm_away' || call == 'alarm_arm_night')
-            data["ignore_open_sensors"] = "True"  // no need to check as the panel already called openSensors
+          //if (call == 'alarm_arm_home' || call == 'alarm_arm_away' || call == 'alarm_arm_night')
+          //  data["ignore_open_sensors"] = "True"  // no need to check as the panel already called openSensors
 
-          this.hass.callService(this.platform, call, data);
+          //this.hass.callService(this.platform, call, data);
+          this.hass.callService('alarm_control_panel', call, data);
         }
 
         //Restart Home Assistant

--- a/custom_components/bwalarm/services.yaml
+++ b/custom_components/bwalarm/services.yaml
@@ -1,7 +1,7 @@
 # Describes the format for available alarm control panel services
 
 alarm_disarm:
-  description: Send the alarm the command for disarm.
+  description: Sends disarm command to alarm control panel.
   fields:
     entity_id:
       description: Name of alarm control panel to disarm.
@@ -10,41 +10,41 @@ alarm_disarm:
       description: An optional code to disarm the alarm control panel with.
       example: 1234
 
-alarm_arm_home:
-  description: Send the alarm the command for arm home.
+alarm_safe_arm_home:
+  description: Sends arm home command to alarm control panel. Does not set alarm if there are active sensors detected.
   fields:
     entity_id:
-      description: Name of alarm control panel to arm home.
-      example: 'alarm_control_panel.downstairs'
+      description: Name of alarm control panel to control.
+      example: 'alarm_control_panel.home'
     code:
-      description: An optional code to arm home the alarm control panel with.
+      description: An optional code to arm home the alarm control panel with. If "override" used, set alarm immediately.
       example: 1234
     ignore_open_sensors:
-      description: When True, arm even with active sensors. Default is False
-      example: True
+      description: "When True, set alarm even if active sensors detected. Default: False"
+      example: "True"
 
-alarm_arm_away:
-  description: Send the alarm the command for arm away.
+alarm_safe_arm_away:
+  description: Sends arm away command to alarm control panel. Does not set alarm if there are active sensors detected.
   fields:
     entity_id:
-      description: Name of alarm control panel to arm away.
+      description: Name of alarm control panel to control.
       example: 'alarm_control_panel.downstairs'
     code:
-      description: An optional code to arm away the alarm control panel with.
+      description: An optional code to arm away the alarm control panel with. If "override" used, set alarm immediately.
       example: 1234
     ignore_open_sensors:
-      description: When True, arm even with active sensors. Default is False
-      example: True
+      description: "When True, set alarm even if active sensors detected. Default: False"
+      example: "True"
 
-alarm_arm_night:
-  description: Send the alarm the command for arm night.
+alarm_safe_arm_night:
+  description: Sends arm night command to alarm control panel. Does not set alarm if there are active sensors detected.
   fields:
     entity_id:
-      description: Name of alarm control panel to arm night.
-      example: 'alarm_control_panel.downstairs'
+      description: Name of alarm control panel to control.
+      example: 'alarm_control_panel.home'
     code:
-      description: An optional code to arm night the alarm control panel with.
+      description: An optional code to arm night the alarm control panel with. If "override" used, set alarm immediately.
       example: 1234
     ignore_open_sensors:
-      description: When True, arm even with active sensors. Default is False
-      example: True
+      description: "When True, set alarm even if active sensors detected. Default: False"
+      example: "True"


### PR DESCRIPTION
Bring back alarm_arm_xxx service calls (enabling alarm_control_panel.alarm_arm_xxx ones) AND adding safe versions that are configurable via their's parameters and do not set alarm if there are active sensors detected by default, i.e bwalarm.alarm_safe_arm_xxx.
Fixes #19