### PR TITLE
Proper handling of Require code to arm & small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# bwalarm (akasma74 edition)
+# BWAlarm (ak74 edition)
 
 ## Disclaimer
 This fork was created to maintain the original [bwalarm](https://github.com/gazoscalvertos/Hass-Custom-Alarm) custom component until its author is back.
-Feel free to create a new issue or pull request here **if you downloaded code from my repo**.
+Feel free to create a new issue or pull request here **if you downloaded code from this repository**.
 The corresponding HA thread [here](https://community.home-assistant.io/t/bwalarm-akasma74-edition/113666)
 
 ## How to: installation
@@ -18,7 +18,7 @@ Using [HACS](https://github.com/custom-components/hacs):
 If you have HACS custom component already installed, do the following:
 1. Click on Community in the left hand side menu on Home Assistant frontend
 2. Click Store
-3. Scroll down until you see Fork of Yet another take on alarm and click on it
+3. Scroll down until you see ```BWAlarm (ak74 edition)``` and  click on it
 4. If necessary, select Show Beta from the drop-down menu under SETTINGS
 5. Optionally, select version from Available versions drop-down list (it has the latest one selected by default).
 6. Click INSTALL
@@ -55,7 +55,7 @@ Currently the update process is pretty much similar to installation:
 
 Using [HACS](https://github.com/custom-components/hacs):
 1. Click on Community in the left hand side menu on Home Assistant frontend
-2. Click on Fork of Yet another take on alarm in Integrations
+2. Click on ```BWAlarm (ak74 edition)``` in Integrations
 3. Click UPGRADE
 
 Bear in mind that if you use this method, it only updates ```custom_components/bwalarm/``` folder and ALL user data inside that folder will be lost upon every update.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can always configure your alarm using web interface or by editing your ```bw
 
 The default password to access the settings page is: **HG28!!&dn**
 
-For more details please refer to the [configuration description](https://github.com/akasma74/Hass-Custom-Alarm/blob/master/custom_components/bwalarm/resources/doc/configuration.md and [notes](https://github.com/akasma74/Hass-Custom-Alarm/blob/master/custom_components/bwalarm/resources/doc/notes.md)).
+For more details please refer to the [configuration description](https://github.com/akasma74/Hass-Custom-Alarm/blob/master/custom_components/bwalarm/resources/doc/configuration.md) and [notes](https://github.com/akasma74/Hass-Custom-Alarm/blob/master/custom_components/bwalarm/resources/doc/notes.md).
 Some automation examples are available [here](https://github.com/akasma74/Hass-Custom-Alarm/tree/master/custom_components/bwalarm/resources/doc/examples).
 
 ## How to: update

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ You can always configure your alarm using web interface or by editing your ```bw
 
 The default password to access the settings page is: **HG28!!&dn**
 
-For more details please refer to the [configuration description](https://github.com/akasma74/Hass-Custom-Alarm/blob/master/guidance/configuration.md).
+For more details please refer to the [configuration description](https://github.com/akasma74/Hass-Custom-Alarm/blob/master/custom_components/bwalarm/resources/doc/configuration.md and [notes](https://github.com/akasma74/Hass-Custom-Alarm/blob/master/custom_components/bwalarm/resources/doc/notes.md)).
+Some automation examples are available [here](https://github.com/akasma74/Hass-Custom-Alarm/tree/master/custom_components/bwalarm/resources/doc/examples).
 
 ## How to: update
 

--- a/custom_components/bwalarm/TODO
+++ b/custom_components/bwalarm/TODO
@@ -5,7 +5,7 @@ alarm_control_panel.py
 - Enable MQTT without HA restart/(WIP)
 - validate MQTT using schema
 - state[mode]xxx_time appear in yaml with (when that section edited via Settings) OR without quotes, investigate
-- code_arm_required: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/alarm_control_panel/__init__.py#L91
+- store persistence file in .storage ?
 
 
 Milestones
@@ -21,6 +21,9 @@ panel.html
 - prev style buttons/code panel?
 - use another way to find out the integration's entity_id (as someone can change name: in bwalarm.yaml and there is no panel_custom.yaml anymore!)
 - service calls: this.platform hardcoded, change
+
+Docs:
+- add something like this about use cases: https://community.home-assistant.io/t/bwalarm-akasma74-edition/113666/222
 
 
 

--- a/custom_components/bwalarm/TODO
+++ b/custom_components/bwalarm/TODO
@@ -5,8 +5,6 @@ alarm_control_panel.py
 - Enable MQTT without HA restart/(WIP)
 - validate MQTT using schema
 - state[mode]xxx_time appear in yaml with (when that section edited via Settings) OR without quotes, investigate
-- store persistence file in .storage ?
-
 
 Milestones
 - remove obsolete enable_perimeter_mode attribute and perimeter_mode stuff from the code
@@ -24,8 +22,6 @@ panel.html
 
 Docs:
 - add something like this about use cases: https://community.home-assistant.io/t/bwalarm-akasma74-edition/113666/222
-
-
 
 FRs:
 

--- a/custom_components/bwalarm/manifest.json
+++ b/custom_components/bwalarm/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "bwalarm",
-  "name": "Fork of Yet another take on an alarm",
+  "name": "BWAlarm (ak74 edition)",
   "documentation": "https://github.com/akasma74/Hass-Custom-Alarm",
   "dependencies": [],
   "codeowners": ["@akasma74"],

--- a/custom_components/bwalarm/resources/doc/configuration.md
+++ b/custom_components/bwalarm/resources/doc/configuration.md
@@ -8,6 +8,8 @@
 - code: '9876' **#[REQUIRED, digits] should consist of one or more digits ie '6482' ensure your passcode is encapsulated by quotes**
 - panic_code: '1234' **#[OPTIONAL, digits] Panic Code should consist of one or more digits ie '1234' ensure your passcode is encapsulated by quotes, it needs to be different to your standard alarm code. This enables a special panic mode. This can be used under duress to deactivate the alarm which would appear to the unseeing eye as deactivated however a special attribute [panic_mode] listed under the alarm_control_panel.[identifier] will change to ACTIVE. This status could be used in your automations to send a notification to someone else police/spouse/sibling/neighbour that you are under duress. To deactive this mode arm then disarm your alarm in the usual manner.**
 
+- code_to_arm: False **#[OPTIONAL, Boolean] False by default. If True, to set alarm via panel/MQTT command/service call you need to supply a master/user code**
+
 - alarm: automation.alarm_triggered **#[REQUIRED, String] The automation to fire when the alarm has been triggered**
 - warning: automation.alarm_warning **#[OPTIONAL, String] The automation to fire when the alarm has been tripped**
 #### [OPTIONAL SETTINGS]

--- a/custom_components/bwalarm/resources/panel.html
+++ b/custom_components/bwalarm/resources/panel.html
@@ -9,7 +9,7 @@ v
     const _NAME = 'Alarm Panel';
     const _URL = 'https://github.com/akasma74/Hass-Custom-Alarm';
     // don't forget to change HaPanelAlarm.version below!
-    const _VERSION = 'v1.10.0';
+    const _VERSION = 'v1.10.0 dev';
 
     if (!window.CUSTOM_UI_LIST) window.CUSTOM_UI_LIST = [];
     window.CUSTOM_UI_LIST.push({
@@ -1418,7 +1418,7 @@ v
             switches:             { type: Array, value: [] },
 
             errors:               { type: Array },
-            version:              { type: String, value: 'v1.10.0'},
+            version:              { type: String, value: 'v1.10.0 dev'},
 
             camera_update_interval: { type: Number, value: 5000 }, // ms
 
@@ -2356,7 +2356,7 @@ v
             var http = new XMLHttpRequest();
             http.open('HEAD', url, false);
             http.send();
-            console.log("urlExists(%s) status = ", url, http.status)
+            //console.log("urlExists(%s) status = ", url, http.status)
             return http.status != 404;
           }
           catch(err){

--- a/custom_components/bwalarm/resources/panel.html
+++ b/custom_components/bwalarm/resources/panel.html
@@ -9,7 +9,7 @@ v
     const _NAME = 'Alarm Panel';
     const _URL = 'https://github.com/akasma74/Hass-Custom-Alarm';
     // don't forget to change HaPanelAlarm.version below!
-    const _VERSION = 'v1.10.0 dev';
+    const _VERSION = 'v1.10.1';
 
     if (!window.CUSTOM_UI_LIST) window.CUSTOM_UI_LIST = [];
     window.CUSTOM_UI_LIST.push({
@@ -1418,7 +1418,7 @@ v
             switches:             { type: Array, value: [] },
 
             errors:               { type: Array },
-            version:              { type: String, value: 'v1.10.0 dev'},
+            version:              { type: String, value: 'v1.10.1'},
 
             camera_update_interval: { type: Number, value: 5000 }, // ms
 

--- a/custom_components/bwalarm/resources/panel.html
+++ b/custom_components/bwalarm/resources/panel.html
@@ -2136,6 +2136,14 @@ v
             //console.log("monitorAlarm: call carouselChange to make sure Settings is not displayed");
             this.carouselChange(this.$.controls);
           }
+
+          // add handler to remove shake effect (otherwise it shakes only once)
+          const content = this.$.content;
+          if (content){
+            content.addEventListener("animationend", (e) => {
+              content.classList.remove("shake");
+            });
+          }
         }
 
         requiresCode(){
@@ -2410,6 +2418,12 @@ v
           switch (call){
             //Check for open sensors before arming the alarm.
             case 'arm':
+              // do we have a code here?
+              if (this.alarm.attributes.code_to_arm == true && !this.code) {
+                console.log("empty codes are not supported!");
+                this.$.content.classList.add('shake');
+                break;
+              }
               this.attemptArmMode = ev.target.getAttribute('data-arm');
               try {
                 if ( this.hasOpenSensors(this.attemptArmMode) ) {
@@ -2440,9 +2454,15 @@ v
 
             //Disarm the alarm.
             case 'disarm':
-              this.alarmService('alarm_disarm');
+              // do we have a code here?
+              if (this.code) {
+                this.alarmService('alarm_disarm');
+              }
+              else {
+                console.log("empty codes are not supported!");
+                this.$.content.classList.add('shake');
+              }
               break;
-
           }
 
           //Reset the display alarm codes
@@ -2731,36 +2751,6 @@ v
         //Call the service to update the yaml file
         settingsUpdateUser(user, command){
           this.hass.callService('alarm_control_panel', 'alarm_yaml_user', {'user': user, 'command': command });
-        }
-
-        //Check if there are open sensors
-        checkOpenSensors_orig(call){
-          //check to see how many open sensors there are, if none arm alarm
-          if (this.opencount == 0) return false;
-
-          for (var sensor in this.allsensors){
-            //is it open?
-            //yes
-            // TODO: IT DOES NOT SEEM TO SUPPORT CUSTOM ON STATES, CHANGE!!
-            if (['on', 'open', 'true', 'detected', 'unlocked'].indexOf(this.allsensors[sensor].state.toLowerCase()) > -1){
-            //is it in the override list?
-              var overrideMode = '';
-              if (call == 'alarm_arm_home') var overrideMode = 'armed_home';
-              if (call == 'alarm_arm_away') var overrideMode = 'armed_away';
-              if (call == 'alarm_arm_night') var overrideMode = 'armed_night';
-
-              //No: return so display message
-              if (this.alarm.attributes.states[overrideMode].override.indexOf(this.allsensors[sensor].entity_id) == -1){
-
-                //display the warning message and shake
-                this.attemptedArm = true;
-
-                this.$.content.classList.add('shake');
-
-                return true;
-              }
-            }
-          }
         }
 
         service_name2arm_state(service_name) {


### PR DESCRIPTION
Main change - fixed issue when it was possible to set alarm by just clicking Home/Away/Night button even if Require code to arm was Enabled.
Now it should work correctly for panel, service calls and MQTT commands.
Also, the panel won't make a service call if no code entered to disarm or arm (if code required).

Apart form that, the integration's name has changed to BWAlarm (ak74 edition)