### PR TITLE
`REQUIREMENTS` moved from code to manifest.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,14 @@ To get things working with Home Assistant (HA) you need to add the following to 
 alarm_control_panel: !include resources/bwalarm/bwalarm.yaml
 ```
 You may need to restart HA if the integration doesn't load first time as HA will need to install a dependency (`ruamel.yaml`).  
-Note that if your Home Assistant's version is older than 0.93, you need to uncomment the `REQUIREMENTS` line at the beginning of `custom_components/bwalarm/alarm_control_panel.py` file and type in the ruamel.yaml's version used by Home Assistant (can be found in Home Assistant's `setup.py` on [GitHub](https://github.com/home-assistant/home-assistant)).
+Note that if your Home Assistant's version is older than 0.93, you need to uncomment the `REQUIREMENTS` line at the beginning of `custom_components/bwalarm/alarm_control_panel.py` file and type in the ruamel.yaml's version used by Home Assistant (can be found in Home Assistant's `setup.py` file on [GitHub](https://github.com/home-assistant/home-assistant)).  
+
 It's advisable to start with a new ```bwalarm.yaml``` file (located in ```resources/bwalarm``` folder) with the minimum configuration set:
 ```
 platform: bwalarm
 ```
 You can always configure your alarm using web interface or by editing your ```bwalarm.yaml``` directly.  
-The default password to access the settings page is: **HG28!!&dn**  
+The default password to access the Settings tab of the panel is **HG28!!&dn**  
 For more details please refer to the [configuration variables](custom_components/bwalarm/resources/doc/configuration.md) page, [examples](custom_components/bwalarm/resources/doc/examples.md) and [notes](custom_components/bwalarm/resources/doc/notes.md).  
 
 ## How to: update

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ To get things working with Home Assistant (HA) you need to add the following to 
 alarm_control_panel: !include resources/bwalarm/bwalarm.yaml
 ```
 You may need to restart HA if the integration doesn't load first time as HA will need to install a dependency (`ruamel.yaml`).  
-Note that if your Home Assistant's version is older than 0.93, you need to uncomment the `REQUIREMENTS` line at the beginning of `custom_components/bwalarm/alarm_control_panel.py` file and type in the ruamel.yaml's version used by Home Assistant (can be found in Home Assistant's `setup.py` file on [GitHub](https://github.com/home-assistant/home-assistant)).  
 
 It's advisable to start with a new ```bwalarm.yaml``` file (located in ```resources/bwalarm``` folder) with the minimum configuration set:
 ```
@@ -58,3 +57,5 @@ Updating by using HACS (even if you initially installed the integration manually
 ## After update (for all methods)
 Please note that the component's code is loaded on Home Assistant startup and the panels' code (`panel.html`) is cached by a browser.  
 Therefore, **every time you update** no matter how, **you HAVE to clear cache of ALL of your browsers and then RESTART Home Assistant** for changes to take effect.  
+  
+Note that if your Home Assistant's version is older than 0.93, you need to uncomment the `REQUIREMENTS` line at the beginning of `custom_components/bwalarm/alarm_control_panel.py` file and type in the ruamel.yaml's version used by Home Assistant (can be found in Home Assistant's `setup.py` file on [GitHub](https://github.com/home-assistant/home-assistant)).

--- a/README.md
+++ b/README.md
@@ -57,5 +57,5 @@ Updating by using HACS (even if you initially installed the integration manually
 ## After update (for all methods)
 Please note that the component's code is loaded on Home Assistant startup and the panels' code (`panel.html`) is cached by a browser.  
 Therefore, **every time you update** no matter how, **you HAVE to clear cache of ALL of your browsers and then RESTART Home Assistant** for changes to take effect.  
-  
-Note that if your Home Assistant's version is older than 0.93, you need to uncomment the `REQUIREMENTS` line at the beginning of `custom_components/bwalarm/alarm_control_panel.py` file and type in the ruamel.yaml's version used by Home Assistant (can be found in Home Assistant's `setup.py` file on [GitHub](https://github.com/home-assistant/home-assistant)).
+
+If your Home Assistant's version is older than 0.93, you need to uncomment the `REQUIREMENTS` line at the beginning of `custom_components/bwalarm/alarm_control_panel.py` file and type in the ruamel.yaml's version used by Home Assistant (can be found in Home Assistant's `setup.py` file on [GitHub](https://github.com/home-assistant/home-assistant)).

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ To get things working with Home Assistant (HA) you need to add the following to 
 alarm_control_panel: !include resources/bwalarm/bwalarm.yaml
 ```
 You may need to restart HA if the integration doesn't load first time as HA will need to install a dependency (`ruamel.yaml`).  
+Note that if your Home Assistant's version is older than 0.93, you need to uncomment the `REQUIREMENTS` line at the beginning of `custom_components/bwalarm/alarm_control_panel.py` file and type in the ruamel.yaml's version used by Home Assistant (can be found in Home Assistant's `setup.py` on [GitHub](https://github.com/home-assistant/home-assistant)).
 It's advisable to start with a new ```bwalarm.yaml``` file (located in ```resources/bwalarm``` folder) with the minimum configuration set:
 ```
 platform: bwalarm

--- a/custom_components/bwalarm/alarm_control_panel.py
+++ b/custom_components/bwalarm/alarm_control_panel.py
@@ -1,7 +1,7 @@
 #### Code of the bwalarm integration ####
 
 # For legacy installations, this is not used in HA > 0.93
-REQUIREMENTS = ['ruamel.yaml==0.15.42']
+#REQUIREMENTS = ['ruamel.yaml==HomeAssistant_ruamel.yaml_version']
 
 import logging
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/bwalarm/manifest.json
+++ b/custom_components/bwalarm/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://github.com/akasma74/Hass-Custom-Alarm",
   "dependencies": [],
   "codeowners": ["@akasma74"],
-  "requirements": ["ruamel.yaml==0.15.42"]
+  "requirements": ["ruamel.yaml==0.15.100"]
 }

--- a/custom_components/bwalarm/resources/doc/configuration.md
+++ b/custom_components/bwalarm/resources/doc/configuration.md
@@ -225,7 +225,8 @@
 <a id="states-armed_night"></a>
 &nbsp;&nbsp;&nbsp; **armed_night**  
 &nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp; _(map) (Optional)_  
-&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp; Configuration variables for the `Night` mode. Check [`enable_night_mode`](#enable_night_mode) variable for details.  
+&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp; Configuration variables for the `Night` mode.  
+&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp; Check [`enable_night_mode`](#enable_night_mode) variable description for details.  
 &nbsp;  
 <a id="states-armed_night-immediate"></a>
 &nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp; **immediate**  
@@ -748,7 +749,7 @@ All service calls use domain `alarm_control_panel` and accept the `entity_id` pa
 Service calls `alarm_arm_home`, `alarm_arm_away` and `alarm_arm_night` accept optional `code` parameter that has extended specification compared to [passcode requirements](#passcode_requirements) by allowing a special code "override".  
 This special code tells the alarm to set immediately, while with a normal code the alarm will change its state to `pending` first for the corresponding `pending_time` and then change to a corresponding Armed state.  
 These service calls also take into account value of [`ignore_open_sensors`](#ignore_open_sensors) configuration variable. If it is `false` (default value, i.e safe arming), the alarm will be set only if there is no active sensors detected.  
-  
+
 There is `set_ignore_open_sensors` service call that allows to change value of `ignore_open_sensors` configuration variable.  
 Please refer to the [services' description](../../services.yaml) and the [Examples](examples.md#service-calls) page for more details.  
 

--- a/custom_components/bwalarm/resources/doc/configuration.md
+++ b/custom_components/bwalarm/resources/doc/configuration.md
@@ -751,7 +751,7 @@ This special code tells the alarm to set immediately, while with a normal code t
 These service calls also take into account value of [`ignore_open_sensors`](#ignore_open_sensors) configuration variable. If it is `false` (default value, i.e safe arming), the alarm will be set only if there is no active sensors detected.  
 
 There is `set_ignore_open_sensors` service call that allows to change value of `ignore_open_sensors` configuration variable.  
-Please refer to the [services' description](../../services.yaml) and the [Examples](examples.md#service-calls) page for more details.  
+Please refer to the [services' description](../../services.yaml) and [examples](examples.md#service-calls) for more details.  
 
 ### MQTT INTERFACE
 When MQTT interface is [enabled](#mqtt-enable_mqtt), the alarm publishes its status to the [state topic](#mqtt-state_topic) and listens to commands on the [command topic](#mqtt-command_topic).  

--- a/custom_components/bwalarm/resources/panel.html
+++ b/custom_components/bwalarm/resources/panel.html
@@ -5,7 +5,7 @@
     const _NAME = 'Alarm Panel';
     const _URL = 'https://github.com/akasma74/Hass-Custom-Alarm';
     // don't forget to change HaPanelAlarm.version below!
-    const _VERSION = 'v1.10.4';
+    const _VERSION = 'DEV';
 
     if (!window.CUSTOM_UI_LIST) window.CUSTOM_UI_LIST = [];
     window.CUSTOM_UI_LIST.push({
@@ -1420,7 +1420,7 @@
             switches:             { type: Array, value: [] },
 
             errors:               { type: Array },
-            version:              { type: String, value: 'v1.10.4'},
+            version:              { type: String, value: 'DEV'},
 
             camera_update_interval: { type: Number, value: 5000 }, // ms
 

--- a/custom_components/bwalarm/resources/panel.html
+++ b/custom_components/bwalarm/resources/panel.html
@@ -5,7 +5,7 @@
     const _NAME = 'Alarm Panel';
     const _URL = 'https://github.com/akasma74/Hass-Custom-Alarm';
     // don't forget to change HaPanelAlarm.version below!
-    const _VERSION = 'DEV';
+    const _VERSION = 'v1.11.0';
 
     if (!window.CUSTOM_UI_LIST) window.CUSTOM_UI_LIST = [];
     window.CUSTOM_UI_LIST.push({
@@ -1420,7 +1420,7 @@
             switches:             { type: Array, value: [] },
 
             errors:               { type: Array },
-            version:              { type: String, value: 'DEV'},
+            version:              { type: String, value: 'v1.11.0'},
 
             camera_update_interval: { type: Number, value: 5000 }, // ms
 


### PR DESCRIPTION
As required by HA newer than 0.92 requirements should be in manifest.json rather than in python code.
Users of HA older than 0.93 should change their code as per Readme

Fix #56 