### PR TITLE
add state_duration attribute when pending/warning, to use with countdown timer in custom lovelace card

### DIFF
--- a/custom_components/bwalarm/alarm_control_panel.py
+++ b/custom_components/bwalarm/alarm_control_panel.py
@@ -768,6 +768,11 @@ class BWAlarm(AlarmControlPanelEntity):
 
             'py_version':               sys.version_info,
         }
+  
+        if (self._state == STATE_ALARM_PENDING):
+           results['state_duration'] = self._states[self._armstate][CONF_PENDING_TIME]
+        elif (self._state == STATE_ALARM_WARNING):
+           results['state_duration'] = self._states[self._armstate][CONF_WARNING_TIME]
 
         if (CONF_USERS in self._config):
             results[CONF_USERS] = copy.deepcopy(self._config[CONF_USERS])


### PR DESCRIPTION
this publishes an attribute when in pending/warning state, with the value in seconds of the current state.   this can be used by a custom Lovelace card to show an accurate countdown timer.  example card: https://github.com/jcooper-korg/AlarmPanel